### PR TITLE
Add support for formatting the index in specific ways

### DIFF
--- a/.github/workflows/pyright.yaml
+++ b/.github/workflows/pyright.yaml
@@ -25,7 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v17
-      - uses: DeterminateSystems/magic-nix-cache-action@v9
       - name: Cache Python virtual environment
         uses: actions/cache@v4
         with:

--- a/driverbrainz.py
+++ b/driverbrainz.py
@@ -123,10 +123,7 @@ TRANSLATED_MUSICBRAINZ_WORK_IDENTIFIERS = {}
 
 
 # https://stackoverflow.com/a/28777781/9835303
-def write_roman(num):
-    if not num.is_integer():
-        return num
-
+def write_roman(num: int) -> str:
     roman = OrderedDict()
     roman[1000] = "M"
     roman[900] = "CM"
@@ -253,20 +250,17 @@ STANDARD_JAPANESE_NUMERALS = {
 #
 # The requested type can be kanji, hiragana, hepburn, or formal_kanji.
 def convert_to_japanese_numeral(num: int, requested_type: str) -> str:
-    if not num.is_integer():
-        return num
-
     if requested_type not in ["kanji", "hiragana", "hepburn", "formal_kanji"]:
-        return None
+        return ""
 
     # I'm not worrying about numbers larger than 99,999 right now
     if (num // 10000) > 9:
-        return None
-    string = ""
-    number = num
+        return ""
+    string: str = ""
+    number: int = num
     for power in [4, 3, 2, 1, 0]:
-        power_of_ten = math.pow(10, power)
-        quotient = number // power_of_ten
+        power_of_ten: int = int(math.pow(10, power))
+        quotient: int = number // power_of_ten
         if quotient > 0:
             if power == 0:
                 string += STANDARD_JAPANESE_NUMERALS[quotient][requested_type]
@@ -287,9 +281,6 @@ def convert_to_japanese_numeral(num: int, requested_type: str) -> str:
 #
 # The requested format can be kanji, hiragana, hepburn, formal_kanji, numeral, or roman_numeral.
 def format_number(number: int, format: str) -> str:
-    if not number.is_integer():
-        return number
-
     if format not in [
         "kanji",
         "hiragana",
@@ -298,7 +289,7 @@ def format_number(number: int, format: str) -> str:
         "numeral",
         "roman_numeral",
     ]:
-        return None
+        return ""
 
     if format == "numeral":
         return f"{number}"
@@ -335,12 +326,11 @@ def format_index(index: str, title: dict, format_map: dict) -> str:
     format = format_map[title["language"]][title["script"]]
     if format == "numeral":
         return index
-    number = None
     if not index.isnumeric():
         return index
     number = float(index)
     if not number.is_integer():
-        return number
+        return str(number)
     number = int(number)
     return format_number(number, format)
 

--- a/driverbrainz.py
+++ b/driverbrainz.py
@@ -30,51 +30,6 @@ MUSICBRAINZ_CREATE_RELEASE_GROUP_URL = (
 )
 BOOKBRAINZ_CREATE_WORK_URL = "https://bookbrainz.org/work/create"
 
-# Prerequisites
-#
-# Firefox
-# Disable the browser.translations.automaticallyPopup option in about:config
-# Install the https://www.greasespot.net/[GreaseMonkey] extension in Firefox
-# Install the SUPER MIND CONTROL II X Turbo user script for MusicBrainz
-# https://github.com/jesus2099/konami-command/raw/master/mb_SUPER-MIND-CONTROL-II-X-TURBO.user.js
-# Install the Guess Unicode Punctuation user script for MusicBrainz
-#
-# The clipse clipboard manager in the Sway desktop is necessary since I use it to manage the contents of the clipboard.
-# It's bound to the keyboard shortcut Super+I
-#
-# Requires fcitx5 for the input of Unicode characters.
-# sudo rpm-ostree install fcitx5-autostart
-# sudo systemctl reboot
-#
-# This script is used on an Adafruit MacroPad using CircuitPython.
-# It requires the MacroPad library plus all of its dependencies to be copied over to the lib directory on the MacroPad.
-
-# Usage
-#
-# Configure the constants below as necessary for the works of the series you want to add.
-# Set the volume start and end values, which are inclusive, accordingly.
-# Save the updated script to the MacroPad in the code.py file.
-# Copy the name for the first volume in the original language.
-# This copied text will be used as the title and immediately followed by the index value.
-# Open a browser window and focus on it.
-# Click the desired key to create the series.
-# Always test with 1 or 2 works in the series before doing more.
-#
-
-# 0 - Create a series of MusicBrainz works along with their associated translated works
-# 1 - Create a series of MusicBrain release groups
-# 3 - Create a series of BookBrainz works along with their associated translated works
-
-# The second title must always be the title for the translated works
-# Remember to use the appropriate Unicode characters!
-#
-# Apostrophe:: ’
-# Dash:: ‐
-# Ellipsis:: …
-# Multiplication Sign:: ×
-# Quotation Marks:: “”
-#
-
 MUSICBRAINZ_WORK_TYPE = "Prose"
 
 MUSICBRAINZ_WRITER = ""
@@ -351,7 +306,6 @@ def format_number(number: int, format: str) -> str:
     if format == "roman_numeral":
         return write_roman(number)
 
-    # if format not in ["kanji", "hiragana", "hepburn", "formal_kanji"]:
     return convert_to_japanese_numeral(number, format)
 
 
@@ -393,7 +347,6 @@ def format_index(index: str, title: dict, format_map: dict) -> str:
 
 # Sanitize a sort field by removing leading pairs of brackets, parentheses, and similar punctuation
 def sanitize_sort(sanitized_sort_title: str) -> str:
-    # sanitized_sort_title = sort_title
     if sanitized_sort_title.startswith("【"):
         sanitized_sort_title = sanitized_sort_title.replace("【", "", 1)
         if sanitized_sort_title.endswith("】"):
@@ -457,7 +410,6 @@ def bookbrainz_set_title(
         by=By.XPATH, value="//button[text()='Guess']"
     )
     sort_copy_button = driver.find_element(by=By.XPATH, value="//button[text()='Copy']")
-    # sort_name_text_box = driver.find_element(by=By.XPATH, value=".input-group:nth-child(2) > .form-control")
     # todo Make more accurate by relative to label
     sort_name_text_box = driver.find_element(
         by=By.XPATH,
@@ -514,12 +466,6 @@ def bookbrainz_set_title(
         )
     )
 
-    # language_text_box.send_keys(title["language"])
-    # wait.until(EC.visibility_of_element_located((By.ID, "react-select-language-option-0")))
-    # first_language_option = driver.find_element(by=By.ID, value="react-select-language-option-0")
-    # first_language_option.click()
-    # wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".row:nth-child(4) .text-success")))
-
 
 def bookbrainz_add_aliases(driver, aliases):
     wait = WebDriverWait(driver, timeout=200)
@@ -554,8 +500,6 @@ def bookbrainz_add_aliases(driver, aliases):
             by=By.XPATH,
             value=f"(//div/div[@class='row']/div[@class='col-lg-4']/div[@class='form-group']/div[@class='input-group']/div[@class='input-group-append']/button[text()='Copy'])[{one_based_index}]",
         )
-        # language_text_box_locator = locate_with(By.XPATH, "react-select-language-input").to_right_of({By.CSS_SELECTOR: f"{row} .input-group > .form-control"})
-        # language_text_box = driver.find_element(language_text_box_locator)
         language_text_box = driver.find_element(
             by=By.XPATH,
             value=f"(//div/div[@class='row']/div[@class='col-lg-4']/div[@class='form-group']/div[starts-with(@class,'Select')]/div[starts-with(@class,'react-select__control')]/div[starts-with(@class,'react-select__value-container')]/div/div[@class='react-select__input']/input[@id='react-select-language-input'])[{one_based_index}]",
@@ -587,7 +531,6 @@ def bookbrainz_add_aliases(driver, aliases):
                 )
             )
         )
-        # "css=.react-select__control--is-focused > .react-select__value-container"
         language_text_box.send_keys(alias["language"])
         wait.until(
             EC.visibility_of_element_located(
@@ -625,10 +568,11 @@ def bookbrainz_add_aliases(driver, aliases):
             )
         else:
             close_button.click()
-            # todo Or check title? Waiting for the modal dialog to disappear
             wait.until(EC.visibility_of(add_aliases_button))
 
 
+# todo This almost certainly doesn't work.
+# Use XPATH.
 def bookbrainz_add_identifiers(driver, identifiers):
     wait = WebDriverWait(driver, timeout=200)
     add_identifiers_button = driver.find_element(by=By.CSS_SELECTOR, value=".wrap")
@@ -666,7 +610,6 @@ def bookbrainz_add_identifiers(driver, identifiers):
             )
         else:
             close_button.click()
-            # todo Or check title? Waiting for the modal dialog to disappear
             wait.until(EC.visibility_of_element_located(add_identifiers_button))
 
 
@@ -708,38 +651,16 @@ def bookbrainz_add_series(driver, series, index):
         By.ID, "react-select-relationshipEntitySearchField-input"
     )
     other_entity_text_box.send_keys(series)
-    # wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".progress-bar")))
     wait.until(
         EC.visibility_of_element_located(
             (By.XPATH, "//div[@class='progress']/div[@aria-valuenow=50]")
         )
     )
-    # relationship_text_box = None
-    # if is_first_relationship:
-    # wait.until(EC.visibility_of_element_located((By.CLASS_NAME, "react-select__input")))
-    # react_select_input_span = driver.find_element(By.XPATH, "//div[@class='react-select__input']/input")
-    # relationship_text_box = react_select_input_span.find_element(By.TAG_NAME, "input")
     relationship_text_box_locator = locate_with(
         By.XPATH, "//div[@class='react-select__input']/input"
     ).below(other_entity_text_box)
     relationship_text_box = driver.find_element(relationship_text_box_locator)
-    # else:
-    #     wait.until(EC.visibility_of_element_located((By.ID, "react-select-4-input")))
-    #     relationship_text_box = driver.find_element(By.ID, "react-select-4-input")
-    # relationship_text_box.click()
     relationship_text_box.send_keys("is part of")
-    # relationship_selection = None
-    # if select_input_index == 2:
-    # "react-select__option react-select__option--is-focused react-select__option--is-selected"
-    # react-select__option--is-selected
-    # react-select__option--is-focused
-    # "react-select__menu-list"
-    # wait.until(EC.visibility_of_element_located((By.XPATH, "//div[@class='react-select__menu-list']/div/div[@class='react-select__option']")))
-    # wait.until(EC.visibility_of_element_located((By.CLASS_NAME, "react-select__menu")))
-    # react_select_menu = driver.find_element(By.CLASS_NAME, "react-select__menu")
-    # react_select_option = react_select_menu.find_element(By.CLASS_NAME, "margin-left-d0")
-    # wait.until(EC.visibility_of_element_located((By.XPATH, "//div[starts-with(@class,'react-select__menu-list')]/div/div[@class='margin-left-d0'][1]")))
-    # react_select_option = driver.find_element(By.XPATH, "//div[starts-with(@class,'react-select__menu-list')]/div/div[@class='margin-left-d0'][1]")
     wait.until(
         EC.visibility_of_element_located(
             (
@@ -752,9 +673,6 @@ def bookbrainz_add_series(driver, series, index):
         By.XPATH,
         "//div[starts-with(@class,'react-select__menu-list')]/div/div[starts-with(@class,'margin-left-d')][1]",
     )
-    # else:
-    # wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, f"#react-select-{select_input_index + 1}-option-0 > .margin-left-d0")))
-    # relationship_selection = driver.find_element(By.CSS_SELECTOR, f"#react-select-{select_input_index + 1}-option-0 > .margin-left-d0")
     react_select_option.click()
     wait.until(
         EC.visibility_of_element_located(
@@ -806,8 +724,6 @@ def bookbrainz_add_relationship(driver, relationship):
     other_entity_text_box = driver.find_element(
         By.ID, "react-select-relationshipEntitySearchField-input"
     )
-    # if relationship["id"] == "PASTE_FROM_CLIPBOARD":
-    #     paste(macropad)
     other_entity_text_box.send_keys(relationship["id"])
     wait.until(
         EC.visibility_of_element_located(
@@ -819,15 +735,6 @@ def bookbrainz_add_relationship(driver, relationship):
         By.XPATH, "//div[@class='react-select__input']/input"
     ).below(other_entity_text_box)
     relationship_text_box = driver.find_element(relationship_text_box_locator)
-    # relationship_text_box = driver.find_element(By.XPATH, "//div[@class='react-select__input']/input")
-    # relationship_text_box = driver.find_element(By.XPATH, f"//div[@class='react-select__input']/input[contains(@value,'{relation}')]")
-    # if is_first_relationship:
-    # wait.until(EC.visibility_of_element_located((By.ID, f"react-select-{select_input_index}-input")))
-    # relationship_text_box = driver.find_element(By.ID, f"react-select-{select_input_index}-input")
-    # else:
-    #     wait.until(EC.visibility_of_element_located((By.ID, "react-select-4-input")))
-    #     relationship_text_box = driver.find_element(By.ID, "react-select-4-input")
-    # relationship_text_box = driver.find_element(By.CSS_SELECTOR, ".react-select__control--is-focused > .react-select__value-container")
     relationship_text_box.send_keys(relation)
     wait.until(
         EC.visibility_of_element_located(
@@ -841,15 +748,7 @@ def bookbrainz_add_relationship(driver, relationship):
         By.XPATH,
         "//div[starts-with(@class,'react-select__menu-list')]/div/div[starts-with(@class,'margin-left-d')][1]",
     )
-    # relationship_selection = None
-    # if select_input_index == 2:
-    #     wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".margin-left-d0")))
-    #     relationship_selection = driver.find_element(By.CSS_SELECTOR, ".margin-left-d0")
-    # else:
-    #     wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, f"#react-select-{select_input_index + 1}-option-0 > .margin-left-d0")))
-    #     relationship_selection = driver.find_element(By.CSS_SELECTOR, f"#react-select-{select_input_index + 1}-option-0 > .margin-left-d0")
     react_select_option.click()
-    # //small XPATH?
     wait.until(
         EC.visibility_of_element_located(
             (By.XPATH, "//div[@class='progress']/div[@aria-valuenow=100]")
@@ -865,25 +764,6 @@ def bookbrainz_add_relationship(driver, relationship):
     wait.until(EC.visibility_of(add_relationships_button))
 
 
-# original_work = {
-#     "title": {
-#         # "text": "",
-#         "sort": ORIGINAL_WORK_TITLE_SORT,
-#         "language": ORIGINAL_LANGUAGE,
-#     },
-#     "type": "",
-#     "language": "",
-#     "disambiguation": ORIGINAL_WORK_DISAMBIGUATION_COMMENT,
-#     "aliases": original_aliases,
-#     "identifiers": original_identifiers,
-#     "series": BOOKBRAINZ_ORIGINAL_WORK_SERIES,
-#     "relationships": [
-#         {
-#             "writer": BOOKBRAINZ_WRITER,
-#             "illustrator": BOOKBRAINZ_ILLUSTRATOR,
-#         }
-#     ],
-# }
 def bookbrainz_create_work(
     driver,
     work,
@@ -894,7 +774,6 @@ def bookbrainz_create_work(
 ):
     wait = WebDriverWait(driver, timeout=200)
 
-    # driver.close()
     driver.get(BOOKBRAINZ_CREATE_WORK_URL)
 
     wait.until(
@@ -931,15 +810,11 @@ def bookbrainz_create_work(
         index_number_format_map=index_number_format_map,
         sort_index_number_format_map=sort_index_number_format_map,
     )
-    # disambiguation_label = driver.find_element(by=By.XPATH, value="//label[@class='form-label' and span/starts-with(text(),'Disambiguation')]")
-    # disambiguation_text_box_locator = driver.find_element(by=By.XPATH, value=".row:nth-child(5) .form-control")
-    # disambiguation_text_box_locator = locate_with(By.ID, "react-select-language-input").below({By.XPATH: "//div[@class='form-group']/input[@class='form-control']"})
     # todo Make more accurate by relative to label
     disambiguation_text_box = driver.find_element(
         by=By.XPATH,
         value="(//div[@class='form-group']/input[@class='form-control'])[2]",
     )
-    # disambiguation_text_box = driver.find_element(disambiguation_text_box_locator)
     if "disambiguation" in work and work["disambiguation"]:
         disambiguation_text_box.send_keys(work["disambiguation"])
         wait.until(
@@ -1452,12 +1327,8 @@ def main():
     elif "range" in data and data["range"]:
         range_ = [str(i) for i in data["range"]]
 
-    # bookbrainz_original_work = None
     if "bookbrainz_work" in data["original"]:
-        # bookbrainz_original_work = data["original"]["bookbrainz_work"]
         if "bookbrainz_work" in data["translation"]:
-            # if "titles" not in data["translation"] or not data["translation"]["titles"]:
-            #     data["translation"]["titles"] = [data["original"]["titles"][1]]
             if (
                 "type" not in data["translation"]["bookbrainz_work"]
                 or not data["bookbrainz_work"]["translation"]["type"]
@@ -1582,10 +1453,6 @@ def main():
     options.set_preference("browser.cache.memory.capacity", 1_048_576)
 
     driver = webdriver.Firefox(options=options, service=service)
-
-    # FirefoxProfile
-    # profile = driver.profile
-    # profile.DEFAULT_PREFERENCES["frozen"]["browser.cache.memory.capacity"] = 2400
 
     wait = WebDriverWait(driver, timeout=200)
 
@@ -1815,21 +1682,6 @@ def main():
 
             if "titles" not in translation or not translation["titles"]:
                 translation["titles"] = []
-
-            # if (
-            #     "subtitles" in original
-            #     and original["subtitles"]
-            #     and i in original["subtitles"]
-            #     and original["subtitles"][i]
-            #     and "1" in original["subtitles"][i]
-            #     and original["subtitles"][i]["1"]
-            # ):
-            #     translation["subtitles"][i]["0"] = original["subtitles"][i]["1"]
-            # else:
-            #     if "subtitles" in translation and translation["subtitles"]:
-            #         translation["subtitles"] = [{}].append(translation["subtitles"])
-            #     else:
-            #         translation["subtitles"] = []
 
             titles = []
             for title_index, title in enumerate(translation["titles"]):

--- a/driverbrainz.py
+++ b/driverbrainz.py
@@ -4,7 +4,6 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.support.relative_locator import locate_with
-from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.firefox.options import Options as FirefoxOptions
 
 import argparse
@@ -675,23 +674,27 @@ def bookbrainz_set_work_type(driver, work_type):
     wait = WebDriverWait(driver, timeout=200)
     work_type_text_box = driver.find_element(By.ID, "react-select-workType-input")
     work_type_text_box.send_keys(work_type)
-    # work_type_index = 0
-    # if work_type == "Novel":
-    #     work_type_index = 1
-    wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".margin-left-d10")))
-    if work_type == "Novel":
-        work_type_text_box.send_keys(Keys.ARROW_DOWN)
-        # todo Wait
-        # work_type_index = 1
-    work_type_text_box.send_keys(Keys.ENTER)
-    # work_type_option = driver.find_element(by=By.CSS_SELECTOR, value=f"#react-select-workType-option-{work_type_index} > .margin-left-d10")
-    # work_type_option.click()
     wait.until(
         EC.visibility_of_element_located(
-            (By.XPATH, "//div[@id='content']/form/div/div/div[3]/div/div/div/small")
+            (
+                By.XPATH,
+                f"//div[starts-with(@class,'react-select__menu-list')]/div[starts-with(@class,'react-select__option')]/div[text()='{work_type}']",
+            )
         )
     )
-    # wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".row:nth-child(4) .text-success")))
+    work_type_option = driver.find_element(
+        by=By.XPATH,
+        value=f"//div[starts-with(@class,'react-select__menu-list')]/div[starts-with(@class,'react-select__option')]/div[text()='{work_type}']",
+    )
+    work_type_option.click()
+    wait.until(
+        EC.visibility_of_element_located(
+            (
+                By.XPATH,
+                f"//div[@class='form-group']/label[@class='form-label' and text()='Type']/../div/div[starts-with(@class,'react-select__control')]/div[starts-with(@class,'react-select__value-container')]/div[starts-with(@class,'react-select__single-value') and text()='{work_type}']",
+            )
+        )
+    )
 
 
 def bookbrainz_add_series(driver, series, index):

--- a/driverbrainz.py
+++ b/driverbrainz.py
@@ -773,6 +773,7 @@ def bookbrainz_add_series(driver, series, index):
 BOOKBRAINZ_RELATIONSHIP_VERB = {
     "adaptation": "is an adaptation of",
     "adapter": "adapted",
+    "contributor": "contributed to",
     "edition": "contains",
     "illustrator": "illustrated",
     "letterer": "lettered",
@@ -1497,6 +1498,16 @@ def main():
                             ].append(
                                 {"role": "provided art for", "id": relationship["id"]}
                             )
+                    elif relationship["role"] in ["contributor"]:
+                        if {
+                            "role": "contributor",
+                            "id": relationship["id"],
+                        } not in data["translation"]["bookbrainz_work"][
+                            "relationships"
+                        ]:
+                            data["translation"]["bookbrainz_work"][
+                                "relationships"
+                            ].append({"role": "contributor", "id": relationship["id"]})
 
     # To have a special title sort in MusicBrainz, it's necessary to add an alias.
     # aliases = []

--- a/examples/manga_template.json
+++ b/examples/manga_template.json
@@ -57,7 +57,7 @@
     "language": "Japanese",
     "disambiguation": "<English Title>, manga, Japanese",
     "bookbrainz_work": {
-      "type": "manga",
+      "type": "Comics/manga/sequential art",
       "series": [
         {
           "id": "",

--- a/examples/manga_template.json
+++ b/examples/manga_template.json
@@ -1,22 +1,43 @@
 {
+  "index_number_format_map": {
+    "English": {
+      "Latin": "numeral"
+    },
+    "Japanese": {
+      "Kanji": "numeral",
+      "Latin": "numeral"
+    }
+  },
+  "sort_index_number_format_map": {
+    "English": {
+      "Latin": "numeral"
+    },
+    "Japanese": {
+      "Kanji": "numeral",
+      "Latin": "numeral"
+    }
+  },
   "original": {
     "titles": [
       {
         "text": "|subtitle|",
         "sort": "|subtitle|",
-        "language": "Japanese"
+        "language": "Japanese",
+        "script": "Kanji"
       },
       {
         "text": "|subtitle|",
-        "sort": "COPY",
+        "sort": "|subtitle|",
         "language": "English",
-        "primary": true
+        "primary": true,
+        "script": "Latin"
       },
       {
         "text": "|subtitle|",
         "sort": "|subtitle|",
         "language": "Japanese",
-        "primary": false
+        "primary": false,
+        "script": "Latin"
       }
     ],
     "subtitles": {
@@ -29,7 +50,7 @@
           "title": "Chapter |index|: Hot Pot"
         },
         "2": {
-          "title": "Dai |index| Wa Mizutaki"
+          "title": "Dai |index|‐wa Mizutaki"
         }
       }
     },

--- a/parse_wikipedia_chapters.py
+++ b/parse_wikipedia_chapters.py
@@ -65,6 +65,7 @@ def remove_extra_spaces_hiragana(input: str) -> str:
         "、",
         "・",
         "·",
+        ",",
         "!",
         "?",
         ".",


### PR DESCRIPTION
This makes it possible to specify the format to use for an index based off of the script and language of a title.
Selection of the work type uses XPATH and no longer requires the keyboard hacks to select the proper type.
Note that the full name of the work type must be specified exactly, including using the correct case.
Certain characters are automatically stripped from the beginning of sort fields, like square brackets and hashtags.

The Wikipedia parser now supports specying the language code to use for the Wikipedia page.